### PR TITLE
WIP initial attempt at fargate monitoring structure; needs work

### DIFF
--- a/packages/truemark-cdk-lib/aws-ecs/lib/extended-fargate-cluster.ts
+++ b/packages/truemark-cdk-lib/aws-ecs/lib/extended-fargate-cluster.ts
@@ -22,7 +22,10 @@ export class ExtendedFargateCluster extends StandardFargateCluster {
       dashboardName: 'Fargate Cluster',
     });
 
-    fargateMonitoring.handler.addMediumHeader("Cluster Monitoring")
+    fargateMonitoring.handler.monitorFargateService({
+      fargateService: this.service,
+      humanReadableName: 'Fargate Monitor'
+    })
   }
 
 }

--- a/packages/truemark-cdk-lib/aws-ecs/lib/extended-fargate-cluster.ts
+++ b/packages/truemark-cdk-lib/aws-ecs/lib/extended-fargate-cluster.ts
@@ -1,0 +1,29 @@
+import {StandardFargateCluster, StandardFargateClusterProps} from "./standard-fargate-cluster";
+import {Construct} from "constructs";
+import { initMonitoring } from './fargate-alarms';
+import { FargateServiceMonitoringProps } from "cdk-monitoring-constructs";
+
+/**
+ * Properties for FargateService.
+ */
+export interface ExtendedFargateClusterProps extends FargateServiceMonitoringProps, StandardFargateClusterProps {
+
+}
+
+/**
+ * Extended version of the StandardFargateCluster that supports monitoring & alarms.
+ */
+export class ExtendedFargateCluster extends StandardFargateCluster {
+
+  constructor(scope: Construct, id: string, props: ExtendedFargateClusterProps) {
+    super(scope, id);
+
+    const fargateMonitoring = initMonitoring(StandardFargateCluster, {
+      dashboardName: 'Fargate Cluster',
+    });
+
+    fargateMonitoring.handler.addMediumHeader("Cluster Monitoring")
+  }
+
+}
+

--- a/packages/truemark-cdk-lib/aws-ecs/lib/extended-fargate-service.ts
+++ b/packages/truemark-cdk-lib/aws-ecs/lib/extended-fargate-service.ts
@@ -1,0 +1,30 @@
+import {StandardFargateService, StandardFargateServiceProps} from "./standard-fargate-service";
+import {Construct} from "constructs";
+import { initMonitoring } from './fargate-alarms';
+import { FargateServiceMonitoringProps } from "cdk-monitoring-constructs";
+
+/**
+ * Properties for FargateService.
+ */
+export interface ExtendedFargateServiceProps extends FargateServiceMonitoringProps, StandardFargateServiceProps {
+
+}
+
+/**
+ * Extended version of the StandardFargateService that supports monitoring & alarms.
+ */
+export class ExtendedFargateService extends StandardFargateService {
+
+  constructor(scope: Construct, id: string, props: ExtendedFargateServiceProps) {
+    super(scope, id);
+
+    const fargateMonitoring = initMonitoring(StandardFargateService, {
+      dashboardName: 'Fargate Services'
+    });
+
+    fargateMonitoring.handler.monitorFargateService({
+      fargateService: this.service,
+      humanReadableName: 'Fargate Monitor'
+    })
+  }
+}

--- a/packages/truemark-cdk-lib/aws-ecs/lib/fargate-alarms.ts
+++ b/packages/truemark-cdk-lib/aws-ecs/lib/fargate-alarms.ts
@@ -1,0 +1,23 @@
+import { Construct } from 'constructs';
+import { MonitoringFacade } from 'cdk-monitoring-constructs';
+
+export interface MonitoringConfig {
+  readonly dashboardName: string;
+}
+
+export interface MonitoringContext {
+  readonly handler: MonitoringFacade;
+}
+
+export const initMonitoring = function(scope: Construct, config: MonitoringConfig): MonitoringContext {
+
+  const defaultAlarmNamePrefix = config.dashboardName;
+  return {
+    handler: new MonitoringFacade(scope, config.dashboardName, {
+      alarmFactoryDefaults: {
+        actionsEnabled: true,
+        alarmNamePrefix: defaultAlarmNamePrefix,
+      },
+    }),
+  }
+}


### PR DESCRIPTION
_note: I do not expect that this patch is complete. This is a first attempt given my limited understanding of these services._

This patch introduces a few new files that attempt to extend the `standard-fargate-*` with monitoring using the cdk-monitoring-constructs package.

I would appreciate a more detailed review with Erik to clarify what each of the standard services does unique from the others and what monitor thresholds are required. It was difficult to find any relevant examples of what we're trying to accomplish.

While I understand much more of the CDK code than I did a week ago there remain portions that are still a black box.