### PR TITLE
Create DNS entries for additional 'domainNames' of Fargate services

### DIFF
--- a/packages/truemark-cdk-lib/aws-vpc/lib/network-parameters.ts
+++ b/packages/truemark-cdk-lib/aws-vpc/lib/network-parameters.ts
@@ -689,7 +689,7 @@ export class NetworkParameters extends Construct implements IAutomationComponent
           parameterName: this.publicSubnetsParameterPath,
           stringListValue: props.publicSubnetIds
         });
-        this.publicSubnetIds = props.privateSubnetIds;
+        this.publicSubnetIds = props.publicSubnetIds;
       }
       if (props.privateSubnetIds) {
         this.privateSubnetsParameter = new StringListParameter(this, "PrivateSubnets", {


### PR DESCRIPTION
When additional 'domainNames' are specified to an ApplicationFargateService, the additional DNS (Route53) entries were not being created.