### PR TITLE
fixing the wrong kms arn issue

### DIFF
--- a/aws-centergauge/lib/alerts-topic.ts
+++ b/aws-centergauge/lib/alerts-topic.ts
@@ -55,7 +55,8 @@ export class AlertsTopic extends ExtendedConstruct {
     });
 
     const masterKey =
-      props.masterKey ?? Alias.fromAliasName(this, 'AwsSnsKey', 'aws/sns');
+      props.masterKey ??
+      Alias.fromAliasName(this, 'AwsSnsKey', 'alias/aws/sns');
 
     const dlq = new StandardQueue(this, 'Dlq', {
       maxReceiveCount: -1,


### PR DESCRIPTION
Invalid arn arn:aws:kms:us-west-2:<accountid>:aws/sns (Service: AWSKMS; Status Code: 400; Error Code: NotFoundException; Request ID: 8eeed77c-a3f8-4768-8874-283892326e61; Proxy: null) (Service: AmazonSNS; Status Code: 400; Error Code: KMSNotFound; Request ID: 3e0b3a2f-4c93-5ce9-8fe1-64cdda39e2c5; Proxy: null)"

This change fixes the wrong kms arn issue 