### PR TITLE
Enable the ability to pass an ecs task role when creating a task definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.19.1
+
+### Added
+
+- Enable the ability to pass an ecs task role as part of  `StandardFargateServiceProps`.
+
 ## v1.19.0
 
 ### Changed

--- a/aws-ecs/lib/standard-fargate-service.ts
+++ b/aws-ecs/lib/standard-fargate-service.ts
@@ -19,7 +19,7 @@ import {LogConfiguration} from './log-configuration';
 import {SecurityGroup, SubnetSelection, SubnetType} from 'aws-cdk-lib/aws-ec2';
 import {LogGroup, RetentionDays} from 'aws-cdk-lib/aws-logs';
 import {Duration, RemovalPolicy, Stack} from 'aws-cdk-lib';
-import {PolicyStatement} from 'aws-cdk-lib/aws-iam';
+import {IRole, PolicyStatement} from 'aws-cdk-lib/aws-iam';
 import {BasicStepScalingPolicyProps} from 'aws-cdk-lib/aws-autoscaling';
 import {IMetric} from 'aws-cdk-lib/aws-cloudwatch';
 import {ScalingSchedule} from 'aws-cdk-lib/aws-applicationautoscaling';
@@ -291,6 +291,14 @@ export interface StandardFargateServiceProps extends ExtendedConstructProps {
    *
    */
   readonly otel?: OtelConfig;
+
+  /**
+   * The name of the IAM role that grants containers in the task permission to call other AWS resources.
+   * Best practice is not to assign a value to this field, and let the CDK create a role for you.
+   *
+   * @default - A task role is automatically created for you.
+   */
+  readonly taskRole?: IRole;
 }
 
 /**
@@ -386,6 +394,9 @@ export class StandardFargateService extends ExtendedConstruct {
     });
 
     const taskDefinition = new FargateTaskDefinition(this, 'Resource', {
+      ...(props.taskRole && {
+        taskRole: props.taskRole,
+      }),
       cpu: props.cpu ?? 2048,
       memoryLimitMiB: props.memoryLimitMiB ?? 4096,
       ephemeralStorageGiB: props.ephemeralStorageGiB,


### PR DESCRIPTION
Enable the ability to pass an ecs task role when creating a task definition