### PR TITLE
Enable use of task role name rather than using the full role created outside the cdk stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.19.2
+
+### Changed
+
+- Replacing passing of the entire task role with passing the task role name only for the `StandardFargateServiceProps`.
+
 ## v1.19.1
 
 ### Added


### PR DESCRIPTION
Enable use of task role name rather than using the full role created outside the cdk stack.