### PR TITLE
Fix log group name conflicts for custom resources

### DIFF
--- a/.changeset/wet-melons-itch.md
+++ b/.changeset/wet-melons-itch.md
@@ -1,0 +1,6 @@
+---
+"truemark-cdk-lib": patch
+---
+
+Fixed log group conflicts
+  

--- a/cdk/src/aws-cloudfront/lib/invalidation.ts
+++ b/cdk/src/aws-cloudfront/lib/invalidation.ts
@@ -6,7 +6,7 @@ import {
   PhysicalResourceId,
 } from 'aws-cdk-lib/custom-resources';
 import {Construct} from 'constructs';
-import {configureLogGroupForFunction} from '../../aws-lambda/lib/function-log-options';
+import {configureLogGroupForCustomResource} from '../../aws-lambda/lib/function-log-options';
 
 /**
  * Properties for Invalidation.
@@ -67,9 +67,9 @@ export class Invalidation extends Construct {
       physicalResourceId: PhysicalResourceId.of(now),
     };
 
-    const logGroup = configureLogGroupForFunction(
-      scope,
-      `${id}LogGroup`,
+    const logGroup = configureLogGroupForCustomResource(
+      this,
+      'LogGroup',
       props,
     );
 

--- a/cdk/src/aws-dynamodb/lib/batch-write-item.ts
+++ b/cdk/src/aws-dynamodb/lib/batch-write-item.ts
@@ -6,7 +6,7 @@ import {
   PhysicalResourceId,
 } from 'aws-cdk-lib/custom-resources';
 import {Construct} from 'constructs';
-import {configureLogGroupForFunction} from '../../aws-lambda/lib/function-log-options';
+import {configureLogGroupForCustomResource} from '../../aws-lambda/lib/function-log-options';
 
 export type BatchWriteItemKey = {
   Key: Record<string, any>;
@@ -61,9 +61,9 @@ export class BatchWriteItem extends Construct {
 
     const tableNames = Object.keys(props.items.RequestItems);
 
-    const logGroup = configureLogGroupForFunction(
-      scope,
-      `${id}LogGroup`,
+    const logGroup = configureLogGroupForCustomResource(
+      this,
+      'LogGroup',
       props,
     );
 

--- a/cdk/src/aws-dynamodb/lib/put-item.ts
+++ b/cdk/src/aws-dynamodb/lib/put-item.ts
@@ -6,7 +6,7 @@ import {
   PhysicalResourceId,
 } from 'aws-cdk-lib/custom-resources';
 import {Construct} from 'constructs';
-import {configureLogGroupForFunction} from '../../aws-lambda/lib/function-log-options';
+import {configureLogGroupForCustomResource} from '../../aws-lambda/lib/function-log-options';
 
 /**
  * Properties for PutItem.
@@ -55,9 +55,9 @@ export class PutItem extends Construct {
       physicalResourceId: PhysicalResourceId.of(Date.now().toString()),
     };
 
-    const logGroup = configureLogGroupForFunction(
-      scope,
-      `${id}LogGroup`,
+    const logGroup = configureLogGroupForCustomResource(
+      this,
+      'LogGroup',
       props,
     );
 

--- a/cdk/src/aws-lambda/lib/function-log-options.ts
+++ b/cdk/src/aws-lambda/lib/function-log-options.ts
@@ -1,6 +1,6 @@
 import {Names, RemovalPolicy, Stack} from 'aws-cdk-lib';
 import type * as lambda from 'aws-cdk-lib/aws-lambda';
-import {LogGroup, RetentionDays} from 'aws-cdk-lib/aws-logs';
+import {type ILogGroup, LogGroup, RetentionDays} from 'aws-cdk-lib/aws-logs';
 import type {Construct} from 'constructs';
 
 /**
@@ -78,6 +78,53 @@ export function configureLogGroupForFunction(
   return new LogGroup(scope, `${id}LogGroup`, {
     logGroupName: logConfig?.logGroupName ?? `/aws/lambda/${functionName}`,
     retention: logConfig?.retention ?? RetentionDays.THREE_DAYS,
+    removalPolicy: RemovalPolicy.DESTROY,
+  });
+}
+
+/**
+ * Options for configuring the log group of a custom resource.
+ */
+export interface CustomResourceLogOptions {
+  /**
+   * The log group to use. If provided, it is returned as-is.
+   */
+  readonly logGroup?: ILogGroup;
+  /**
+   * The retention period in days for the log group. Default is 3 days.
+   */
+  readonly logRetention?: number;
+}
+
+/**
+ * Configure the log group for a custom resource (e.g. AwsCustomResource).
+ *
+ * Unlike {@link configureLogGroupForFunction}, this does not attempt to predict
+ * a `/aws/lambda/...` name. Custom resources are backed by a framework-managed
+ * provider Lambda whose name we don't control, so a predicted name is both
+ * meaningless and prone to collisions when truncated to CloudWatch's 64
+ * character limit (multiple custom resources in one stack sharing a long
+ * stack/construct id prefix would resolve to the same name and fail to deploy).
+ *
+ * Instead this lets CloudFormation assign a unique physical name, while still
+ * applying retention and a DESTROY removal policy.
+ *
+ * @param scope The scope in which to create the log group (the construct itself).
+ * @param id The id of the log group construct.
+ * @param props The log configuration.
+ * @returns The log group.
+ */
+export function configureLogGroupForCustomResource(
+  scope: Construct,
+  id: string,
+  props: CustomResourceLogOptions,
+): ILogGroup {
+  if (props.logGroup) {
+    return props.logGroup;
+  }
+  return new LogGroup(scope, id, {
+    retention:
+      (props.logRetention as RetentionDays) ?? RetentionDays.THREE_DAYS,
     removalPolicy: RemovalPolicy.DESTROY,
   });
 }


### PR DESCRIPTION
`Invalidation`, `PutItem`, and `BatchWriteItem` each predicted a Lambda log group name (`/aws/lambda/<stackName>-<id>-<hash>`) via `configureLogGroupForFunction`. That prediction is wrong for these `AwsCustomResource`-backed constructs:

- The unique hash is derived from the **parent scope**, so it's identical across sibling constructs.
- It's appended at the end of the name and gets truncated away at CloudWatch's 64-char limit.

So two such resources in one stack sharing a long id prefix resolved to the **same** `LogGroupName` and failed to deploy.

This adds `configureLogGroupForCustomResource`, which omits the explicit name and lets CloudFormation assign a unique physical name while still applying retention and a `DESTROY` removal policy. The three constructs now use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)