### PR TITLE
Forward bucketName prop in CloudFrontBucketV2

### DIFF
--- a/.changeset/cloudfront-bucket-name.md
+++ b/.changeset/cloudfront-bucket-name.md
@@ -2,4 +2,4 @@
 "truemark-cdk-lib": minor
 ---
 
-Fixed CloudFrontBucketV2 ignoring the bucketName prop. This is a breaking change: stacks that set bucketName previously had it silently ignored (an auto-generated name was used), so the bucket will now be renamed to the provided value on the next deployment.
+Fixed CloudFrontBucketV2 ignoring the bucketName prop. Stacks that set bucketName previously had it silently ignored and an auto-generated name was used. The value now takes effect, so on the next deployment CloudFormation will replace the bucket to apply the new name (the old bucket is retained or deleted per its removal policy, and any existing objects must be migrated).

--- a/.changeset/cloudfront-bucket-name.md
+++ b/.changeset/cloudfront-bucket-name.md
@@ -1,0 +1,5 @@
+---
+"truemark-cdk-lib": minor
+---
+
+Fixed CloudFrontBucketV2 ignoring the bucketName prop. This is a breaking change: stacks that set bucketName previously had it silently ignored (an auto-generated name was used), so the bucket will now be renamed to the provided value on the next deployment.

--- a/cdk/src/aws-s3/lib/cloud-front-bucket-v2.ts
+++ b/cdk/src/aws-s3/lib/cloud-front-bucket-v2.ts
@@ -19,7 +19,7 @@ import {
   ExtendedConstruct,
   type ExtendedConstructProps,
   StandardTags,
-} from '../../aws-cdk/index';
+} from '../../aws-cdk';
 import {LibStandardTags} from '../../truemark';
 import {type BucketDeploymentConfig, ExtendedBucket} from './extended-bucket';
 
@@ -96,6 +96,7 @@ export class CloudFrontBucketV2 extends ExtendedConstruct {
       versioned: props?.versioned ?? false,
       transferAcceleration: props?.transferAcceleration ?? false,
       eventBridgeEnabled: props?.eventBridgeEnabled ?? false,
+      bucketName: props?.bucketName,
       cors: props?.cors,
     });
     this.bucketName = this.bucket.bucketName;


### PR DESCRIPTION
`CloudFrontBucketV2` declared a `bucketName` prop but never passed it to the underlying `ExtendedBucket`, so setting it was silently ignored and an auto-generated name was always used.

- Forward `bucketName` from props to the `ExtendedBucket`.
- Behavior change: stacks that set `bucketName` will now rename the bucket to the provided value on the next deployment, so this ships as a minor release.