### PR TITLE
Disable pnpm release-age cooldown for CdkPipeline synth build

### DIFF
--- a/.changeset/synth-minimum-release-age.md
+++ b/.changeset/synth-minimum-release-age.md
@@ -1,0 +1,5 @@
+---
+"truemark-cdk-lib": patch
+---
+
+Disable pnpm's `minimumReleaseAge` publish cooldown for the `CdkPipeline` synth build (`PNPM_CONFIG_MINIMUM_RELEASE_AGE=0`). pnpm 11 defaults this to a one-day cooldown, which breaks aws-cdk-lib `NodejsFunction` bundling: that runs an isolated `pnpm install` over a copy of the workspace lockfile without the workspace's `minimumReleaseAgeExclude`, so a freshly published dependency fails the check. The synth build installs the committed, reviewed lockfile with `--frozen-lockfile`, so the cooldown adds no protection there anyway.

--- a/cdk/src/aws-codepipeline/lib/cdk-pipeline.ts
+++ b/cdk/src/aws-codepipeline/lib/cdk-pipeline.ts
@@ -502,6 +502,21 @@ export class CdkPipeline extends Construct {
           privileged: !(props.computeType?.includes('LAMBDA') ?? false),
           computeType: props.computeType ?? ComputeType.SMALL,
           buildImage: props.buildImage ?? LinuxBuildImage.AMAZON_LINUX_2_5,
+          environmentVariables: {
+            // pnpm 11 defaults minimumReleaseAge to 1440 (a 1-day publish
+            // cooldown). The synth build installs the committed, PR-reviewed
+            // lockfile with --frozen-lockfile, so it never resolves new
+            // versions and the cooldown adds no protection here. It does,
+            // however, break aws-cdk-lib NodejsFunction bundling: that runs an
+            // isolated `pnpm install` over a copy of the workspace lockfile
+            // without the workspace's minimumReleaseAgeExclude, so a freshly
+            // published dependency fails the cooldown check. Disable it for the
+            // synth build; the cooldown still applies where it matters, at
+            // lockfile-update time on a developer machine or PR.
+            // pnpm reads its own settings only from the PNPM_CONFIG_ prefix,
+            // not NPM_CONFIG_.
+            PNPM_CONFIG_MINIMUM_RELEASE_AGE: {value: '0'},
+          },
         },
         rolePolicy,
       },


### PR DESCRIPTION
pnpm 11 defaults `minimumReleaseAge` to a one-day publish cooldown. This breaks aws-cdk-lib `NodejsFunction` bundling in the `CdkPipeline` synth build: bundling runs an isolated `pnpm install` over a copy of the workspace lockfile *without* the workspace's `minimumReleaseAgeExclude`, so a freshly published dependency fails the cooldown check and the build errors.

- Set `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0` on the synth CodeBuild step to disable the cooldown there.
- The synth build installs the committed, PR-reviewed lockfile with `--frozen-lockfile`, so it never resolves new versions and the cooldown added no protection there anyway. The cooldown still applies where it matters — at lockfile-update time on a developer machine or PR.